### PR TITLE
Parsing pdf works

### DIFF
--- a/clippings.cabal
+++ b/clippings.cabal
@@ -1,5 +1,5 @@
 name:                clippings
-version:             0.1.2
+version:             0.1.4
 license:             MIT
 synopsis:            A parser/generator for Kindle-format clipping files (`My Clippings.txt`),
 author:              Vikram Verma <me@vikramverma.com>

--- a/src/Text/Kindle/Clippings/Types.hs
+++ b/src/Text/Kindle/Clippings/Types.hs
@@ -3,6 +3,7 @@ module Text.Kindle.Clippings.Types
 , Document (..)
 , Position (..)
 , Location (..)
+, Page     (..)
 , Content  (..)
 ) where
 
@@ -23,9 +24,16 @@ data Document = Document
   } deriving (Eq)
 
 data Position = Position
-  { page     :: Maybe Int
+  { page     :: Maybe Page
   , location :: Maybe Location -- PDFs don't get these.
   } deriving (Eq)
+
+data Page = Page Int | PRegion (Int, Int)
+
+instance Eq Page where
+  Page a   == Page b = a==b
+  PRegion a == PRegion b = a==b
+  _ == _ = False
 
 data Location = Location Int | Region (Int,Int)
 

--- a/src/Text/Kindle/Clippings/Writer.hs
+++ b/src/Text/Kindle/Clippings/Writer.hs
@@ -6,7 +6,7 @@ module Text.Kindle.Clippings.Writer
 import Data.Time.Format (formatTime)
 import Data.Time.LocalTime (LocalTime)
 import System.Locale (defaultTimeLocale)
-import Text.Kindle.Clippings.Types (Clipping(..), Document(..), Position(..), Content(..), Location(..))
+import Text.Kindle.Clippings.Types (Clipping(..), Document(..), Position(..), Content(..), Location(..), Page(..))
 
 instance Show Document where
   show (Document t (Just a)) = t ++ " (" ++ a ++ ")"
@@ -15,13 +15,17 @@ instance Show Document where
 instance Show Position where
   show (Position Nothing (Just l))  = show l
   show (Position Nothing Nothing)   = ""
-  show (Position (Just p) (Just l)) = "on Page " ++ show p ++ " | " ++ show l
-  show (Position (Just p) Nothing)  = "on Page " ++ show p 
+  show (Position (Just p) (Just l)) = show p ++ " | " ++ show l
+  show (Position (Just p) Nothing)  = show p
 
 instance Show Content where
   show (Highlight s) = s
   show (Annotation s)  = s
   show (Bookmark) = ""
+
+instance Show Page where
+  show (Page i) = "on page " ++ show i
+  show (PRegion (p1,p2)) = "on page" ++ show p1 ++ "-" ++ show p2
 
 instance Show Location where
   show (Location i) = "Loc. " ++ show i

--- a/tests/Reader.hs
+++ b/tests/Reader.hs
@@ -6,7 +6,7 @@ import Data.Time.LocalTime (LocalTime(..), TimeOfDay(..))
 import Paths_clippings (getDataFileName)
 import Test.Assert (runAssertions)
 import Text.Kindle.Clippings.Reader (readClipping)
-import Text.Kindle.Clippings.Types (Clipping(..),Location(..),Document(..),Position(..),Content(..))
+import Text.Kindle.Clippings.Types (Clipping(..),Location(..),Page(..),Document(..),Position(..),Content(..))
 import Text.Kindle.Clippings.Writer ()
 import Text.Parsec (parse)
 
@@ -35,11 +35,20 @@ inPw2Fixture = Clipping
   , content  = Highlight "Shinka will"
   }
 
+inPw2simplepdfFixture :: Clipping
+inPw2simplepdfFixture = Clipping
+  { date     = LocalTime (fromGregorian 2014 06 08) (TimeOfDay 20 36 53)
+  , document = Document "Stand on Zanzibar" (Just "John Brunner")
+  , position = Position (Just $ PRegion (4607, 4607)) Nothing
+  , content  = Highlight "Shinka will"
+  }
+
+
 inPw2pdfFixture :: Clipping
 inPw2pdfFixture = Clipping
-  { date     = LocalTime (fromGregorian 2014 07 30) (TimeOfDay 14 02 57)
-  , document = Document "Tyler Cowen-Creative Destruction_ How Globalization Is Changing the World's Cultures-Princeton University Press (2002)_k2opt" (Just "")
-  , position = Position Nothing . Just $ Region (316, 316)
+  { date     = LocalTime (fromGregorian 2014 07 29) (TimeOfDay 7 53 28)
+  , document = Document "Tyler Cowen-Creative Destruction_ How Globalization Is Changing the World's Cultures-Princeton University Press (2002)_k2opt  " (Just "")
+  , position = Position (Just $ PRegion (303, 303)) Nothing
   , content  = Highlight "The fundamental story about consumer taste, in modern times, is not one of dumbing down or of producers seeking to satisfy a homogeneous least common denominator at the expense of quality. Rather, the basic trend is of increasing variety and diversity, at all levels of quality, high and low"
   }
 
@@ -51,17 +60,19 @@ getAuthor = author . document
   
 main :: IO () 
 main = do
-  [clipping, brackets, nested, pw2, pw2pdf] <- mapM (readFile <=< getDataFileName)
+  [clipping, brackets, nested, pw2, pw2pdf, pw2simplepdf] <- mapM (readFile <=< getDataFileName)
     [ "tests/fixtures/clipping.txt"
     , "tests/fixtures/brackets.txt"
     , "tests/fixtures/nested_brackets.txt"
     , "tests/fixtures/pw2clipping.txt"
     , "tests/fixtures/pw2pdfclipping.txt"
+    , "tests/fixtures/pw2simplepdfclipping.txt"
     ]
   runAssertions $ 
     [ ("Fixture should parse to sigfpe clipping.", getClipping clipping == inFixture)
     , ("Brackets in clippings' titles should be preserved." , getTitle (getClipping brackets) == "An Introduction to Statistical Learning: with Applications in R (Springer Texts in Statistics)")
     , ("Nested brackets in clippings' authors should be preserved.", getAuthor (getClipping nested) == Just "G. K. (Gilbert Keith) Chesterton")
     , ("Pw2Fixture should parse to Zanzibar clipping", getClipping pw2 == inPw2Fixture)
+    , ("Pw2simpplepdfFixture should parse to Zanzibar pdf clipping", getClipping pw2simplepdf == inPw2simplepdfFixture)
     , ("Pw2pdfFixture should parse to Tyler clipping", getClipping pw2pdf == inPw2pdfFixture)
     ]

--- a/tests/Reader.hs
+++ b/tests/Reader.hs
@@ -47,7 +47,7 @@ inPw2simplepdfFixture = Clipping
 inPw2pdfFixture :: Clipping
 inPw2pdfFixture = Clipping
   { date     = LocalTime (fromGregorian 2014 07 29) (TimeOfDay 7 53 28)
-  , document = Document "Tyler Cowen-Creative Destruction_ How Globalization Is Changing the World's Cultures-Princeton University Press (2002)_k2opt  " (Just "")
+  , document = Document "Creative Destruction - How Globalization Is Changing the World's Cultures-Princeton University Press (2002)" (Just "Tyler Cowen")
   , position = Position (Just $ PRegion (303, 303)) Nothing
   , content  = Highlight "The fundamental story about consumer taste, in modern times, is not one of dumbing down or of producers seeking to satisfy a homogeneous least common denominator at the expense of quality. Rather, the basic trend is of increasing variety and diversity, at all levels of quality, high and low"
   }

--- a/tests/fixtures/pw2pdfclipping.txt
+++ b/tests/fixtures/pw2pdfclipping.txt
@@ -1,4 +1,4 @@
-Tyler Cowen-Creative Destruction_ How Globalization Is Changing the World's Cultures-Princeton University Press (2002)_k2opt  
+Creative Destruction - How Globalization Is Changing the World's Cultures-Princeton University Press (2002) (Tyler Cowen)
 - Your Highlight on page 303-303 | Added on Tuesday, July 29, 2014 7:53:28 AM
 
 The fundamental story about consumer taste, in modern times, is not one of dumbing down or of producers seeking to satisfy a homogeneous least common denominator at the expense of quality. Rather, the basic trend is of increasing variety and diversity, at all levels of quality, high and low

--- a/tests/fixtures/pw2simplepdfclipping.txt
+++ b/tests/fixtures/pw2simplepdfclipping.txt
@@ -1,0 +1,5 @@
+Stand on Zanzibar (John Brunner)
+- Your Highlight on page 4607-4607 | Added on Friday, June 8, 2014 8:36:53 PM
+
+Shinka will
+==========


### PR DESCRIPTION
But there is a hitch in (I think) title checking because we can parse the simple pdf but the original pdf highlight isn't being parsed even as a location.
I think the issue is because the title has a few spaces before a newline, but I am not very sure. 

Have a look if you get some time.
